### PR TITLE
fix: Python version and dockerpyze version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 maintainers = [
     {name = "Nicolò Boschi", email = "boschi1997@gmail.com"},
 ]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.11,<4.0"
 license = "MIT"
 readme = "README.md"
 keywords = ["poetry", "packaging", "docker", "uv"]

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -226,6 +226,7 @@ ENV PORT=5001
 
 WORKDIR /app
 COPY --from=builder /app/ /app/
+ENV PYTHONPATH="${PYTHONPATH}:/app"
 
 EXPOSE 5001
 RUN echo 'Hello from Dockerfile' > /tmp/hello.txt

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = ">=3.9, <4.0"
+requires-python = ">=3.11, <4.0"
 
 [[package]]
 name = "certifi"
@@ -110,7 +110,7 @@ wheels = [
 
 [[package]]
 name = "dockerpyze"
-version = "2.0.2"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## Error in Python Version

In [`dockerpyze/builder.py#7`](https://github.com/nicoloboschi/dockerpyze/blob/main/dockerpyze/builder.py#L7) `tomllib` is imported.
```python
import tomllib
```
However, `tomllib` is added in Python 3.11, larger than the version restricted in `pyproject.toml`.
Fixed by updating to `requires-python = ">=3.11,<4.0"`

## Version Mismatch of dockerpyze

The version of `dockerpyze` should be 2.1.1
```toml
[[package]]
name = "dockerpyze"
version = "2.1.1"
```

